### PR TITLE
Fixed libcudaHOG patch so rwth_ground_hog detector can be used under …

### DIFF
--- a/detection/monocular_detectors/3rd_party/CMakeLists.txt
+++ b/detection/monocular_detectors/3rd_party/CMakeLists.txt
@@ -17,8 +17,11 @@ ExternalProject_Add(
     libcudaHOG
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libcudaHOG
     URL ${groundHOG_tar}
-		PATCH_COMMAND patch -p0 <SOURCE_DIR>/cudaHOG/cudaHOG.cpp < ${CMAKE_CURRENT_SOURCE_DIR}/libcudaHOG/patch/cudaHOG.cpp.diff
-    CONFIGURE_COMMAND qmake -makefile <SOURCE_DIR>
+    PATCH_COMMAND patch -p0 <SOURCE_DIR>/cudaHOG/cudaHOG.cpp < ${CMAKE_CURRENT_SOURCE_DIR}/libcudaHOG/patch/cudaHOG.cpp.diff
+    COMMAND patch -p0 <SOURCE_DIR>/cudaHOG/cudaHOG.pro < ${CMAKE_CURRENT_SOURCE_DIR}/libcudaHOG/patch/cudaHOG.pro.diff
+    COMMAND patch -p0 <SOURCE_DIR>/cudaHOG/global.h < ${CMAKE_CURRENT_SOURCE_DIR}/libcudaHOG/patch/global.h.diff
+    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/libcudaHOG/patch/fix_boost_dependency.sh <SOURCE_DIR>
+    CONFIGURE_COMMAND /usr/lib/x86_64-linux-gnu/qt5/bin/qmake -makefile <SOURCE_DIR>
     BUILD_COMMAND make
     INSTALL_COMMAND "" #Skipp install step. See below
 )

--- a/detection/monocular_detectors/3rd_party/README.md
+++ b/detection/monocular_detectors/3rd_party/README.md
@@ -5,10 +5,11 @@ This directory contains a cmake wrapper file that will take care of downloading,
 At the moment this library is only needed to build the ground_hog package.
 
 ## Dependencies
-* NVIDIA - CUDA: Please follow instructions: http://developer.download.nvidia.com/compute/cuda/5_5/rel/docs/CUDA_Getting_Started_Linux.pdf or go directly to: https://developer.nvidia.com/cuda-downloads to find the latest version (tested with version 5.5)
+* NVIDIA - CUDA Toolkit: Please follow instructions at https://developer.nvidia.com/cuda-downloads to find the latest version (tested with version 10.1 under Ubuntu 18.04 Bionic)
 	* This requires a NVIDIA graphics card
-	* Make sure to follow the instructions especially the part about exporting the PATH and LD_LIBRARY_PATH variables. Add these statements to your `.bashrc`.
-* qmake (Qt4)
+	* Under more recent Ubuntu versions, you can easily install the CUDA Toolkit via apt-get: e.g. `apt-get install cuda-toolkit-10-1` on Ubuntu Bionic (18.04). Try to match the version of the toolkit to any other CUDA libraries you have already installed via the same method.
+	* If installing by hand, make sure to follow the instructions especially the part about exporting the PATH and LD_LIBRARY_PATH variables. Add these statements to your `.bashrc`.
+* qmake (Qt5)
 
 ## Installation
 As mentioned the cmake file will take care of almost everything. Just follow these simple instructions:
@@ -26,31 +27,11 @@ As mentioned the cmake file will take care of almost everything. Just follow the
 	* Find the line that says: `LIBS += -lcudart -L/usr/local/cuda/lib64` and change it to: `LIBS += -lcudart -L/usr/local/cuda/lib`.
 	* Now run `make` again.
 
-## FURTHER CUDA SDK INSTALLATIONS NOTES FOR UBUNTU 12.04
-* Use SDK 5.5. Versions 6.0 or 6.5 will not work, as they require a newer graphics driver which is not available for 12.04.
-* CORRECTION: Version 6.5 works when removing all nvidia-* drivers and installing the 340 driver supplied with the SDK. Tested on 3.13 kernel. Requires the driver to be re-installed each time a new kernel update is installed.
-* If laptop has Optimus, disable it in the BIOS and set to "discrete graphics"! With Optimus, it is hard to get even the CUDA samples running!
-* Install the graphics driver "nvidia-331-updates" using the "Additional drivers" panel in the system settings GUI.
-* After restart, make sure that the driver is actually in use. If it is activated but not in use according to GUI, make sure it is not blacklisted by checking "sudo modprobe nvidia". Also, running "nvidia-settings" should show info such as GPU frequency, temperature etc.
-* Then install the CUDA SDK 5.5, but when asked if the graphics driver shall be installed, answer "no".
-* vim /etc/ld.so.conf.d/cuda.conf, paste following lines:
-    /usr/local/cuda-5.5/lib64
-    /usr/local/cuda-5.5/lib
-    /usr/lib/nvidia-331-updates/
-* Then run "sudo ldconfig", and next run:
-* cd /usr/lib && sudo ln -s /usr/lib/nvidia-331-updates/libcuda.so libcuda.so
-* To verify, cd ~/NVIDIA_CUDA-5.5_Samples/NVIDIA_CUDA-5.5_Samples/1_Utilities/deviceQueryDrv/ && make && ../../bin/x86_64/linux/release/deviceQueryDrv.exe
-* export PATH=/usr/local/cuda/bin:$PATH
-
-Now perform installation as described above. If there is an error like "missing reference to __cudaInitModule", make sure CUDA SDK version is correct and remove the "build" folder, re-create it & run cmake again! It seems the nvcc compiler is run only once, and if you initially have got a wrong CUDA version, the libcudaHOG.so file is never re-built if you do not first delete the "build" folder!
-
-## IMPORTANT!
-
 * If there is an error "undefined reference to 'QString::fromAscii_helper" while running "make", edit "build/libcudaHOG/src/libcudaHOG/cudaHOG.pro" and remove the lines with the "cudaHOGDetect" and "cudaHOGDump" subdirs!
 
-* If there is an error "/usr/bin/ld: cannot find -lboost_program_options-mt", please make sure you have "libboost_program_options*.*" in your "/usr/lib" directory (use command `locate libboost_program_options`). If you have not yet installed Boost, you can try command `sudo apt-get install libboost_program_options-dev`. Else if you have "libboost_program_options*.*", change 'boost_program_options-mt' to 'boost_program_options' in your Makefile and other files (use command `grep 'boost_program_options-mt' -nr` in the build dir to find these files)
+* If there is an error "/usr/bin/ld: cannot find -lboost_program_options-mt", please make sure you have "libboost_program_options*.*" in your "/usr/lib" directory (use command `locate libboost_program_options`). If you have not yet installed Boost, you can try command `sudo apt-get install libboost_program_options-dev`. Else if you have "libboost_program_options*.*", change 'boost_program_options-mt' to 'boost_program_options' in your Makefile and other files (use command `grep 'boost_program_options-mt' -nr` in the build dir to find these files). As of the ROS Melodic release, this is now done automatically as part of the patching progress.
 
-* If there is an error "nvcc fatal   : Value 'sm_11' is not defined for option 'gpu-architecture'", please make sure the CUDA SDK has been installed and use the command `nvcc --help|grep "Allowed values for this option" -n` to see which gpu architecture is supported (eg. 'compute_20' or 'sm_20'), and change 'sm_11' to others in the files (use command `grep 'sm_11' -nr` in the build dir to find these files)
+* If there is an error "nvcc fatal   : Value 'sm_30' is not defined for option 'gpu-architecture'", please make sure the CUDA SDK has been installed and use the command `nvcc --help|grep "Allowed values for this option" -n` to see which gpu architecture is supported (eg. 'sm_65'), and change 'sm_30' to others in the files (use command `grep 'sm_30' -nr` in the build dir to find these files)
 
 * In case of CUDA Error 999 when launching sample applications from the CUDA SDK, this might be a permissions problem! Try if the samples work when run via sudo. In that case, a dirty workaround is to call one of the applications (e.g. deviceQueryDrv) once in an /etc/init/ script at login-session-start.
 

--- a/detection/monocular_detectors/3rd_party/libcudaHOG/patch/cudaHOG.pro.diff
+++ b/detection/monocular_detectors/3rd_party/libcudaHOG/patch/cudaHOG.pro.diff
@@ -1,0 +1,16 @@
+--- cudaHOG.pro	2020-08-28 21:03:07.901335922 +0200
++++ cudaHOG.pro.patched	2020-08-28 21:42:16.280595822 +0200
+@@ -17,10 +17,11 @@
+ cu.CONFIG += no_link
+ cu.variable_out = OBJECTS
+ 
+-INCLUDEPATH += $(CUDA_INC_PATH)
++#INCLUDEPATH += $(CUDA_INC_PATH)
++#INCPATH = $$replace(INCPATH, -I ,)
+ QMAKE_CUFLAGS += $$QMAKE_CFLAGS
+ ## QMAKE_CUEXTRAFLAGS += -arch=sm_11 --ptxas-options=-v -Xcompiler -fPIC -Xcompiler $$join(QMAKE_CUFLAGS, ",")
+-QMAKE_CUEXTRAFLAGS += -arch=sm_11 -Xcompiler -fPIC -Xcompiler $$join(QMAKE_CUFLAGS, ",")
++QMAKE_CUEXTRAFLAGS += -arch=sm_30 -Xcompiler -fPIC -Xcompiler $$join(QMAKE_CUFLAGS, ",")
+ QMAKE_CUEXTRAFLAGS += $(DEFINES) $(INCPATH) $$join(QMAKE_COMPILER_DEFINES, " -D", -D)
+ QMAKE_CUEXTRAFLAGS += -c
+ 

--- a/detection/monocular_detectors/3rd_party/libcudaHOG/patch/fix_boost_dependency.sh
+++ b/detection/monocular_detectors/3rd_party/libcudaHOG/patch/fix_boost_dependency.sh
@@ -1,0 +1,4 @@
+# This removes the -mt suffix
+cd $1
+echo "Patching boost program options dependency recursively in $PWD"
+grep -rl "boost_program_options-mt" src/ | xargs sed -i 's/boost_program_options-mt/boost_program_options/g'

--- a/detection/monocular_detectors/3rd_party/libcudaHOG/patch/global.h.diff
+++ b/detection/monocular_detectors/3rd_party/libcudaHOG/patch/global.h.diff
@@ -1,0 +1,11 @@
+--- global.h	2012-07-10 10:27:01.000000000 +0200
++++ global.h.patched	2020-08-28 21:06:18.847194030 +0200
+@@ -71,7 +71,7 @@
+ 
+ #ifdef VERBOSE_CUDA_FAILS
+ #define ONFAIL(S) { cudaError_t e = cudaGetLastError(); \
+-					if(e) { printf("%s:%s:"S":%s\n", __FILE__, __FUNCTION__ , cudaGetErrorString(e));\
++					if(e) { printf("%s:%s:" #S ":%s\n", __FILE__, __FUNCTION__ , cudaGetErrorString(e));\
+ 					return -2; } }
+ #else
+ #define ONFAIL(S)


### PR DESCRIPTION
…Ubuntu 18.04

- Reference qt5 directly to avoid confusion with qt4
- Remove -mt lib suffix for boost_program_options
- Fix compilation issues due to newer C++ standard
- Update README for installation of libcudaHOG